### PR TITLE
Removed authority and made it backwards compatible

### DIFF
--- a/concordances/cypher.go
+++ b/concordances/cypher.go
@@ -41,9 +41,14 @@ func (pcw CypherDriver) CheckConnectivity() error {
 }
 
 type neoReadStruct struct {
-	UUID       string     `json:"uuid"`
-	Types      []string   `json:"types"`
-	Identifier Identifier `json:"identifier"`
+	UUID          string        `json:"uuid"`
+	Types         []string      `json:"types"`
+	NeoIdentifier neoIdentifier `json:"neoIdentifier"`
+}
+
+type neoIdentifier struct {
+	Labels []string `json:"labels"`
+	Value  string   `json:"value"`
 }
 
 type neoResultStrunct struct {
@@ -57,7 +62,7 @@ func (pcw CypherDriver) ReadByConceptID(identifiers []string) (concordances Conc
 		Statement: `
 		MATCH (p:Concept)<-[:IDENTIFIES]-(i:Identifier)
 		WHERE p.uuid in {identifiers}
-		RETURN collect({uuid:p.uuid, types:labels(p), Identifier:{authority:i.authority, identifierValue:i.value}}) as rs
+		RETURN collect({uuid:p.uuid, types:labels(p), neoIdentifier:{labels:labels(i), value:i.value}}) as rs
 		`,
 		Parameters: neoism.Props{"identifiers": identifiers},
 		Result:     &results,
@@ -73,7 +78,7 @@ func (pcw CypherDriver) ReadByAuthority(authority string, identifierValues []str
 		Statement: `
 		MATCH (p:Concept)<-[:IDENTIFIES]-(i:Identifier)
 		WHERE i.value in {identifierValues}
-		RETURN collect({uuid:p.uuid, types:labels(p), Identifier:{authority:i.authority, identifierValue:i.value}}) as rs
+		RETURN collect({uuid:p.uuid, types:labels(p), NeoIdentifier:{Labels:labels(i), Value:i.value}}) as rs
 		`,
 		Parameters: neoism.Props{
 			"identifierValues": identifierValues,
@@ -110,8 +115,34 @@ func neoReadStructToConcordances(neo *[]neoReadStruct, env string) (concordances
 		concept.ID = mapper.IDURL(neoCon.UUID)
 		concept.APIURL = mapper.APIURL(neoCon.UUID, neoCon.Types, env)
 		con.Concept = concept
-		con.Identifier = neoCon.Identifier
+		con.Identifier = Identifier{Authority: mapNeoLabelsToAuthorityValue(neoCon.NeoIdentifier.Labels), IdentifierValue: neoCon.NeoIdentifier.Value}
 		concordances.Concordance[i] = con
 	}
 	return concordances
 }
+
+func mapNeoLabelsToAuthorityValue(labelNames []string) (authority string) {
+	for _, label := range labelNames {
+		switch label {
+		case TME_ID_NODE_LABEL:
+			return TME_AUTHORITY
+		case FS_ID_NODE_LABEL:
+			return FS_AUTHORITY
+		case UP_AUTHORITY:
+			return UP_AUTHORITY
+		case LEI_AUTHORITY:
+			return LEI_AUTHORITY
+		}
+	}
+	return ""
+}
+
+const TME_AUTHORITY = "http://api.ft.com/system/FT-TME"
+const FS_AUTHORITY = "http://api.ft.com/system/FACSET"
+const UP_AUTHORITY = "http://api.ft.com/system/UPP"
+const LEI_AUTHORITY = "http://api.ft.com/system/LEI"
+
+const TME_ID_NODE_LABEL = "TMEIdentifier"
+const FS_ID_NODE_LABEL = "FacsetIdentifier"
+const UP_ID_NODE_LABEL = "UPPIdentifier"
+const LEI_ID_NODE_LABEL = "LegalEntityIdentifier"

--- a/concordances/cypher.go
+++ b/concordances/cypher.go
@@ -72,7 +72,7 @@ func (pcw CypherDriver) ReadByAuthority(authority string, identifierValues []str
 	query := &neoism.CypherQuery{
 		Statement: `
 		MATCH (p:Concept)<-[:IDENTIFIES]-(i:Identifier)
-		WHERE i.value in {identifierValues} AND i.authority = {authority}
+		WHERE i.value in {identifierValues}
 		RETURN collect({uuid:p.uuid, types:labels(p), Identifier:{authority:i.authority, identifierValue:i.value}}) as rs
 		`,
 		Parameters: neoism.Props{

--- a/concordances/cypher.go
+++ b/concordances/cypher.go
@@ -128,9 +128,9 @@ func mapNeoLabelsToAuthorityValue(labelNames []string) (authority string) {
 			return TME_AUTHORITY
 		case FS_ID_NODE_LABEL:
 			return FS_AUTHORITY
-		case UP_AUTHORITY:
+		case UP_ID_NODE_LABEL:
 			return UP_AUTHORITY
-		case LEI_AUTHORITY:
+		case LEI_ID_NODE_LABEL:
 			return LEI_AUTHORITY
 		}
 	}
@@ -138,11 +138,11 @@ func mapNeoLabelsToAuthorityValue(labelNames []string) (authority string) {
 }
 
 const TME_AUTHORITY = "http://api.ft.com/system/FT-TME"
-const FS_AUTHORITY = "http://api.ft.com/system/FACSET"
+const FS_AUTHORITY = "http://api.ft.com/system/FACTSET"
 const UP_AUTHORITY = "http://api.ft.com/system/UPP"
 const LEI_AUTHORITY = "http://api.ft.com/system/LEI"
 
 const TME_ID_NODE_LABEL = "TMEIdentifier"
-const FS_ID_NODE_LABEL = "FacsetIdentifier"
+const FS_ID_NODE_LABEL = "FactsetIdentifier"
 const UP_ID_NODE_LABEL = "UPPIdentifier"
 const LEI_ID_NODE_LABEL = "LegalEntityIdentifier"

--- a/concordances/fixtures/Annotations-3fc9fe3e-af8c-4f7f-961a-e5065392bb31-v2.json
+++ b/concordances/fixtures/Annotations-3fc9fe3e-af8c-4f7f-961a-e5065392bb31-v2.json
@@ -1,0 +1,54 @@
+[
+  {
+    "thing": {
+      "id": "http://api.ft.com/things/eac853f5-3859-4c08-8540-55e043719400",
+      "prefLabel": "Fakebook, Inc.",
+      "types": [
+          "http://www.ft.com/ontology/organisation/Organisation",
+          "http://www.ft.com/ontology/company/PublicCompany",
+          "http://www.ft.com/ontology/company/Company"
+      ]
+    },
+    "provenances": [
+      {
+        "scores": [
+          {
+            "scoringSystem": "http://api.ft.com/scoringsystem/FT-RELEVANCE-SYSTEM",
+            "value": 0.8
+          },
+          {
+            "scoringSystem": "http://api.ft.com/scoringsystem/FT-CONFIDENCE-SYSTEM",
+            "value": 0.99
+          }
+        ],
+        "atTime": "2016-01-20T19:43:47.314Z",
+        "agentRole": "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a"
+      }
+    ]
+  },
+  {
+    "thing": {
+      "id": "http://api.ft.com/things/5d1510f8-2779-4b74-adab-0a5eb138fca6",
+      "prefLabel": "The Mall Street Journal",
+      "types": [
+          "http://www.ft.com/ontology/organisation/Organisation"
+      ]
+    },
+    "provenances": [
+      {
+        "scores": [
+          {
+            "scoringSystem": "http://api.ft.com/scoringsystem/FT-RELEVANCE-SYSTEM",
+            "value": 0.9
+          },
+          {
+            "scoringSystem": "http://api.ft.com/scoringsystem/FT-CONFIDENCE-SYSTEM",
+            "value": 0.76
+          }
+        ],
+        "atTime": "2016-01-20T19:43:47.314Z",
+        "agentRole": "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a"
+      }
+    ]
+  }
+]

--- a/concordances/fixtures/Content-3fc9fe3e-af8c-4f7f-961a-e5065392bb31.json
+++ b/concordances/fixtures/Content-3fc9fe3e-af8c-4f7f-961a-e5065392bb31.json
@@ -1,0 +1,18 @@
+{
+  "uuid": "3fc9fe3e-af8c-4f7f-961a-e5065392bb31",
+  "title": "Bitcoin story makes Newsweek the headline",
+  "byline": "By Matthew Garrahan in Los Angeles",
+  "identifiers": [
+    {
+      "authority": "http://api.ft.com/system/FTCOM-METHODE",
+      "identifierValue": "3fc9fe3e-af8c-4f7f-961a-e5065392bb31"
+    }
+  ],
+  "publishedDate": "2014-03-07T19:18:01.000Z",
+  "body": "<body><ft-content type=\"http://www.ft.com/ontology/content/ImageSet\" url=\"http://test.api.ft.com/content/666f7190-a5d4-11e3-278b-978e959e1c97\" data-embedded=\"true\"></ft-content><p>On paper, it looked like the story of the year. Newsweek, it appeared, had identified the founder of <a href=\"http://www.ft.com/intl/indepth/bitcoin\" title=\"Bitcoin in depth - FT.com\">Bitcoin</a>. </p>\n</body>",
+  "brands": [
+    {
+      "id": "http://api.ft.com/things/dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54"
+    }
+  ]
+}


### PR DESCRIPTION
This is so that concordances api can be used with the new manner of Identifiers that we are deploying for v1 at the moment