### PR TITLE
Update identifiers iteration2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*idea
 
 Compiled source #
 ###################
@@ -6,6 +7,6 @@ Compiled source #
 # Logs and databases #
 ######################
 *.log
-public-organisations-api
+public-concordances-api
 
 

--- a/concordances/cypher_test.go
+++ b/concordances/cypher_test.go
@@ -28,7 +28,7 @@ func TestNeoReadByConceptIDToConcordancesMandatoryFields(t *testing.T) {
 	defer deleteAllViaService(assert, peopleRW, organisationRW)
 
 	undertest := NewCypherDriver(db, "prod")
-	cs, found, err := undertest.ReadByConceptID([]string{"868c3c17-611c-4943-9499-600ccded71f3"})
+	cs, found, err := undertest.ReadByConceptID("868c3c17-611c-4943-9499-600ccded71f3")
 	assert.NoError(err)
 	assert.True(found)
 	assert.NotEmpty(cs.Concordance)
@@ -48,7 +48,7 @@ func TestNeoReadByAuthorityToConcordancesMandatoryFields(t *testing.T) {
 	defer deleteAllViaService(assert, peopleRW, organisationRW)
 
 	undertest := NewCypherDriver(db, "prod")
-	cs, found, err := undertest.ReadByAuthority("http://api.ft.com/system/FACTSET", []string{"DANMUR-1"})
+	cs, found, err := undertest.ReadByAuthority("http://api.ft.com/system/FACTSET", "DANMUR-1")
 	assert.NoError(err)
 	assert.True(found)
 	assert.NotEmpty(cs.Concordance)
@@ -68,7 +68,7 @@ func TestNeoReadByAuthorityEmptyConcordancesWhenUnsupportedAuthority(t *testing.
 	defer deleteAllViaService(assert, peopleRW, organisationRW)
 
 	undertest := NewCypherDriver(db, "prod")
-	cs, found, err := undertest.ReadByAuthority("http://api.ft.com/system/UnsupportedAuthority", []string{"DANMUR-1"})
+	cs, found, err := undertest.ReadByAuthority("http://api.ft.com/system/UnsupportedAuthority", "DANMUR-1")
 	assert.NoError(err)
 	assert.False(found)
 	assert.Empty(cs.Concordance)
@@ -102,6 +102,7 @@ func writeJSONToService(service baseftrwapp.Service, pathToJSONFile string, asse
 	errrr := service.Write(inst)
 	assert.NoError(errrr)
 }
+
 func deleteAllViaService(assert *assert.Assertions, peopleRW baseftrwapp.Service, organisationRW baseftrwapp.Service) {
 	peopleRW.Delete("868c3c17-611c-4943-9499-600ccded71f3")
 	organisationRW.Delete("f21a5cc0-d326-4e62-b84a-d840c2209fee")

--- a/concordances/fixtures/Membership-Dan_Murphy-6b278d36-5b30-46a3-b036-55902a9d31ac.json
+++ b/concordances/fixtures/Membership-Dan_Murphy-6b278d36-5b30-46a3-b036-55902a9d31ac.json
@@ -5,12 +5,10 @@
   "organisationUuid": "3e844449-b27f-40d4-b696-2ce9b6137133",
   "inceptionDate": "2010-12-11T00:00:00.000Z",
   "terminationDate": "2012-01-01T00:00:00.000Z",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET",
-      "identifierValue": "3603860"
-    }
-  ],
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "3603860",
+    "uuids": ["6b278d36-5b30-46a3-b036-55902a9d31ac"]
+  },
   "membershipRoles": [
     {
       "roleUuid": "ff9e35f2-63e4-487a-87a4-d82535e047de",

--- a/concordances/fixtures/Membership-Galia_Rimon-9c50e77a-de8a-4f8c-b1dd-09c7730e2c70.json
+++ b/concordances/fixtures/Membership-Galia_Rimon-9c50e77a-de8a-4f8c-b1dd-09c7730e2c70.json
@@ -4,12 +4,10 @@
   "personUuid": "bdacd96e-d2f4-429f-bb61-462e40448409",
   "organisationUuid": "3e844449-b27f-40d4-b696-2ce9b6137133",
   "terminationDate": "2012-05-05T00:00:00.000Z",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET",
-      "identifierValue": "3603860"
-    }
-  ],
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "3603860",
+    "uuids": ["9c50e77a-de8a-4f8c-b1dd-09c7730e2c70"]
+  },
   "membershipRoles": [
     {
       "roleUuid": "5fcfec9c-8ff0-4ee2-9e91-f270492d636c",

--- a/concordances/fixtures/Membership-Nicky_Wrightson-668c103f-d8dc-4938-9324-9c60de726705.json
+++ b/concordances/fixtures/Membership-Nicky_Wrightson-668c103f-d8dc-4938-9324-9c60de726705.json
@@ -4,12 +4,10 @@
   "personUuid": "fa2ae871-ef77-49c8-a030-8d90eae6cf18",
   "organisationUuid": "3e844449-b27f-40d4-b696-2ce9b6137133",
   "inceptionDate": "2012-06-01T00:00:00.000Z",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET",
-      "identifierValue": "3603860"
-    }
-  ],
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "3603860",
+    "uuids": ["668c103f-d8dc-4938-9324-9c60de726705"]
+  },
   "membershipRoles": [
     {
       "roleUuid": "d8bbba91-8a87-4dee-bd1a-f79e8139e5c9",

--- a/concordances/fixtures/Membership-Nicky_Wrightson-c739b972-f41d-43d2-b8d9-5848c92e17f6.json
+++ b/concordances/fixtures/Membership-Nicky_Wrightson-c739b972-f41d-43d2-b8d9-5848c92e17f6.json
@@ -5,12 +5,10 @@
   "organisationUuid": "3e844449-b27f-40d4-b696-2ce9b6137133",
   "inceptionDate": "2009-12-11T00:00:00.000Z",
   "terminationDate": "2012-05-01T00:00:00.000Z",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET",
-      "identifierValue": "3603860"
-    }
-  ],
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "3603860",
+    "uuids": ["c739b972-f41d-43d2-b8d9-5848c92e17f6"]
+  },
   "membershipRoles": [
     {
       "roleUuid": "c7063a20-5ca5-4f7a-8a96-47e946b5739e",

--- a/concordances/fixtures/Membership-Scott_Newton-177de04f-c09a-4d66-ab55-bb68496c9c28.json
+++ b/concordances/fixtures/Membership-Scott_Newton-177de04f-c09a-4d66-ab55-bb68496c9c28.json
@@ -3,12 +3,10 @@
   "prefLabel": "Head of Latin American Research & Strategy",
   "personUuid": "84cec0e1-a866-47bd-9444-d74873b69786",
   "organisationUuid": "3e844449-b27f-40d4-b696-2ce9b6137133",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET",
-      "identifierValue": "3603860"
-    }
-  ],
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "3603860",
+    "uuids": ["177de04f-c09a-4d66-ab55-bb68496c9c2"]
+  },
   "membershipRoles": [
     {
       "roleUuid": "c7063a20-5ca5-4f7a-8a96-47e946b5739e",

--- a/concordances/fixtures/Organisation-Child-f21a5cc0-d326-4e62-b84a-d840c2209fee.json
+++ b/concordances/fixtures/Organisation-Child-f21a5cc0-d326-4e62-b84a-d840c2209fee.json
@@ -1,16 +1,12 @@
 {
   "uuid": "f21a5cc0-d326-4e62-b84a-d840c2209fee",
   "properName": "Awesome, Inc.",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET-EDM",
-      "identifierValue": "003JLG-E"
-    },
-    {
-      "authority": "http://api.ft.com/system/LEI",
-      "identifierValue": "7ZW8QJWVPR4P1J1KQY45"
-    }
-  ],
+  "prefLabel": "Awesome, Inc.",
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "003JLG-E",
+    "uuids": ["f21a5cc0-d326-4e62-b84a-d840c2209fee"],
+    "leiCode": "7ZW8QJWVPR4P1J1KQY45"
+  },
   "parentOrganisation": "3e844449-b27f-40d4-b696-2ce9b6137133",
   "shortName": "Awesome",
   "legalName": "Awesome Inc.",

--- a/concordances/fixtures/Organisation-Main-3e844449-b27f-40d4-b696-2ce9b6137133.json
+++ b/concordances/fixtures/Organisation-Main-3e844449-b27f-40d4-b696-2ce9b6137133.json
@@ -1,16 +1,12 @@
 {
   "uuid": "3e844449-b27f-40d4-b696-2ce9b6137133",
   "properName": "Super, Inc.",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET-EDM",
-      "identifierValue": "003JLG-E"
-    },
-    {
-      "authority": "http://api.ft.com/system/LEI",
-      "identifierValue": "7ZW8QJWVPR4P1J1KQY45"
-    }
-  ],
+  "prefLabel": "Super, Inc.",
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "003JLG-E",
+    "uuids": ["3e844449-b27f-40d4-b696-2ce9b6137133"],
+    "leiCode": "7ZW8QJWVPR4P1J1KQY45"
+  },
   "parentOrganisation": "f9694ba7-eab0-4ce0-8e01-ff64bccb813c",
   "shortName": "Super",
   "legalName": "Super Inc.",

--- a/concordances/fixtures/Organisation-Parent-f9694ba7-eab0-4ce0-8e01-ff64bccb813c.json
+++ b/concordances/fixtures/Organisation-Parent-f9694ba7-eab0-4ce0-8e01-ff64bccb813c.json
@@ -1,16 +1,12 @@
 {
   "uuid": "f9694ba7-eab0-4ce0-8e01-ff64bccb813c",
   "properName": "NIKE, Inc.",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET-EDM",
-      "identifierValue": "000RBW-E"
-    },
-    {
-      "authority": "http://api.ft.com/system/LEI",
-      "identifierValue": "787RXPR0UX0O0XUXPZ81"
-    }
-  ],
+  "prefLabel": "NIKE, Inc.",
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "000RBW-E",
+    "uuids": ["f9694ba7-eab0-4ce0-8e01-ff64bccb813c"],
+    "leiCode": "787RXPR0UX0O0XUXPZ81"
+  },
   "industryClassification": "f21a5cc0-d326-4e62-b84a-d840c2209fee",
   "shortName": "NIKE",
   "legalName": "NIKE, Inc.",

--- a/concordances/fixtures/Person-Dan_Murphy-868c3c17-611c-4943-9499-600ccded71f3.json
+++ b/concordances/fixtures/Person-Dan_Murphy-868c3c17-611c-4943-9499-600ccded71f3.json
@@ -1,13 +1,12 @@
 {
   "uuid": "868c3c17-611c-4943-9499-600ccded71f3",
   "name": "Dan Murphy",
+  "prefLabel": "Dan Murphy",
   "salutation": "Mr.",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET-PPL",
-      "identifierValue": "DANMUR-1"
-    }
-  ],
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "DANMUR-1",
+    "uuids": ["868c3c17-611c-4943-9499-600ccded71f3"]
+  },
   "aliases": [
     "Dan Murphy",
     "dan.murphy"

--- a/concordances/fixtures/Person-Galia_Rimon-bdacd96e-d2f4-429f-bb61-462e40448409.json
+++ b/concordances/fixtures/Person-Galia_Rimon-bdacd96e-d2f4-429f-bb61-462e40448409.json
@@ -1,13 +1,12 @@
 {
   "uuid": "bdacd96e-d2f4-429f-bb61-462e40448409",
   "name": "Galia Rimon",
+  "prefLabel": "Galia",
   "salutation": "Chère Consœur",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET-PPL",
-      "identifierValue": "GALIAR-1"
-    }
-  ],
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "GALIAR-1",
+    "uuids": ["bdacd96e-d2f4-429f-bb61-462e40448409"]
+  },
   "aliases": [
     "Galia Rimon",
     "galia.rimon"

--- a/concordances/fixtures/Person-Nicky_Wrightson-fa2ae871-ef77-49c8-a030-8d90eae6cf18.json
+++ b/concordances/fixtures/Person-Nicky_Wrightson-fa2ae871-ef77-49c8-a030-8d90eae6cf18.json
@@ -1,13 +1,12 @@
 {
   "uuid": "fa2ae871-ef77-49c8-a030-8d90eae6cf18",
   "name": "Nicky Wrightson",
+  "prefLabel": "Nicky",
   "salutation": "Ms.",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET-PPL",
-      "identifierValue": "NICKYW-1"
-    }
-  ],
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "NICKYW-1",
+    "uuids": ["fa2ae871-ef77-49c8-a030-8d90eae6cf18"]
+  },
   "aliases": [
     "Nicky Wrightson",
     "nicky.wrightson"

--- a/concordances/fixtures/Person-Scott_Newton-84cec0e1-a866-47bd-9444-d74873b69786.json
+++ b/concordances/fixtures/Person-Scott_Newton-84cec0e1-a866-47bd-9444-d74873b69786.json
@@ -1,13 +1,12 @@
 {
   "uuid": "84cec0e1-a866-47bd-9444-d74873b69786",
   "name": "Scott Newton",
+  "prefLabel": "Scott",
   "salutation": "Dr.",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET-PPL",
-      "identifierValue": "SCOTTN-1"
-    }
-  ],
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "SCOTTN-1",
+    "uuids": ["84cec0e1-a866-47bd-9444-d74873b69786"]
+  },
   "aliases": [
     "Scott Newton",
     "Mr Cypher"

--- a/concordances/fixtures/Role-5fcfec9c-8ff0-4ee2-9e91-f270492d636c.json
+++ b/concordances/fixtures/Role-5fcfec9c-8ff0-4ee2-9e91-f270492d636c.json
@@ -2,10 +2,8 @@
   "uuid": "5fcfec9c-8ff0-4ee2-9e91-f270492d636c",
   "isBoardRole": false,
   "prefLabel": "Town Crier",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET",
-      "identifierValue": "STR"
-    }
-  ]
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "STR",
+    "uuids": ["5fcfec9c-8ff0-4ee2-9e91-f270492d636c"]
+  }
 }

--- a/concordances/fixtures/Role-Board-ff9e35f2-63e4-487a-87a4-d82535e047de.json
+++ b/concordances/fixtures/Role-Board-ff9e35f2-63e4-487a-87a4-d82535e047de.json
@@ -2,10 +2,8 @@
   "uuid": "ff9e35f2-63e4-487a-87a4-d82535e047de",
   "isBoardRole": true,
   "prefLabel": "Writer/Wizard/Mall Santa/Rasputin Impersonator",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET",
-      "identifierValue": "STR"
-    }
-  ]
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "STR",
+    "uuids": ["ff9e35f2-63e4-487a-87a4-d82535e047de"]
+  }
 }

--- a/concordances/fixtures/Role-c7063a20-5ca5-4f7a-8a96-47e946b5739e.json
+++ b/concordances/fixtures/Role-c7063a20-5ca5-4f7a-8a96-47e946b5739e.json
@@ -2,10 +2,8 @@
   "uuid": "c7063a20-5ca5-4f7a-8a96-47e946b5739e",
   "isBoardRole": false,
   "prefLabel": "Namer of Clouds",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET",
-      "identifierValue": "STR"
-    }
-  ]
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "STR",
+    "uuids": ["c7063a20-5ca5-4f7a-8a96-47e946b5739e"]
+  }
 }

--- a/concordances/fixtures/Role-d8bbba91-8a87-4dee-bd1a-f79e8139e5c9.json
+++ b/concordances/fixtures/Role-d8bbba91-8a87-4dee-bd1a-f79e8139e5c9.json
@@ -2,10 +2,8 @@
   "uuid": "d8bbba91-8a87-4dee-bd1a-f79e8139e5c9",
   "isBoardRole": false,
   "prefLabel": "Penguinologist",
-  "identifiers": [
-    {
-      "authority": "http://api.ft.com/system/FACTSET",
-      "identifierValue": "STR"
-    }
-  ]
+  "alternativeIdentifiers": {
+    "factsetIdentifier": "STR",
+    "uuids": ["d8bbba91-8a87-4dee-bd1a-f79e8139e5c9"]
+  }
 }

--- a/concordances/handlers.go
+++ b/concordances/handlers.go
@@ -120,9 +120,9 @@ func GetConcordances(w http.ResponseWriter, r *http.Request) {
 	//check the first element of concordances - to see if it's canonical and a redirect is required
 	if conceptIDExist && len(concordance.Concordance) > 0 {
 		canonicalConceptID := concordance.Concordance[0].Concept.ID
-		conceptUUID := m.Get("conceptId")
-		if !strings.EqualFold(canonicalConceptID, conceptUUID) {
-			redirectURL := strings.Replace(r.RequestURI, conceptUUID, canonicalConceptID, 1)
+		conceptID := m.Get("conceptId")
+		if !strings.EqualFold(canonicalConceptID, conceptID) {
+			redirectURL := strings.Replace(r.RequestURI, conceptID, canonicalConceptID, 1)
 			w.Header().Set("Location", redirectURL)
 			w.WriteHeader(http.StatusMovedPermanently)
 			return

--- a/concordances/handlers_test.go
+++ b/concordances/handlers_test.go
@@ -1,9 +1,11 @@
 package concordances
 
 import (
+	"errors"
 	"fmt"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,19 +15,28 @@ var (
 	server          *httptest.Server
 	concordanceURL  string
 	isFound         bool
-	conceptIds      []string
-	authorities     []string
+	conceptId       string
+	authorityValue  string
 	actualAuthority string
+	isCanonical     bool
+)
+
+const (
+	alternativeId = "alternativeId"
 )
 
 type mockConcordanceDriver struct{}
 
-func (driver mockConcordanceDriver) ReadByConceptID(ids []string) (concordances Concordances, found bool, err error) {
-	conceptIds = ids
-	return Concordances{}, isFound, nil
+func (driver mockConcordanceDriver) ReadByConceptID(id string) (concordances Concordances, found bool, err error) {
+	if isCanonical {
+		conceptId = id
+	} else {
+		conceptId = alternativeId
+	}
+	return Concordances{[]Concordance{Concordance{Concept: Concept{ID: conceptId}}}}, isFound, nil
 }
-func (driver mockConcordanceDriver) ReadByAuthority(authority string, ids []string) (concordances Concordances, found bool, err error) {
-	authorities = ids
+func (driver mockConcordanceDriver) ReadByAuthority(authority string, id string) (concordances Concordances, found bool, err error) {
+	authorityValue = id
 	actualAuthority = authority
 	return Concordances{}, isFound, nil
 }
@@ -41,90 +52,119 @@ func init() {
 	server = httptest.NewServer(r)
 	concordanceURL = fmt.Sprintf("%s/concordances", server.URL) //Grab the address for the API endpoint
 	isFound = true
+	isCanonical = true
 }
 
 func TestCanGetOneAuthority(t *testing.T) {
 	assert := assert.New(t)
 	isFound = true
+	isCanonical = true
 	req, _ := http.NewRequest("GET", concordanceURL+"?authority=some-authority&identifierValue=some-value", nil)
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(err)
 	assert.EqualValues(200, res.StatusCode)
 	assert.EqualValues(actualAuthority, "some-authority")
-	assert.Len(authorities, 1)
-	assert.Contains(authorities, "some-value")
+	assert.Equal("some-value", authorityValue)
 }
 
-func TestCanGetMultipleIdentifiersByAuthority(t *testing.T) {
+func TestCanNotGetMultipleIdentifiersByAuthority(t *testing.T) {
 	assert := assert.New(t)
 	isFound = true
+	isCanonical = true
 	req, _ := http.NewRequest("GET", concordanceURL+"?authority=some-authority&identifierValue=some-value&identifierValue=some-value2", nil)
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(err)
-	assert.EqualValues(200, res.StatusCode)
-	assert.EqualValues(actualAuthority, "some-authority")
-	assert.Len(authorities, 2)
-	assert.Contains(authorities, "some-value")
-	assert.Contains(authorities, "some-value2")
+
+	assert.EqualValues(400, res.StatusCode)
+	msg, err := ioutil.ReadAll(res.Body)
+	assert.NoError(err)
+	assert.Contains(string(msg), multipleAuthorityValuesNotSupported)
 }
 
 func TestReturnBadRequestGivenMoreThanOneAuthority(t *testing.T) {
 	assert := assert.New(t)
 	isFound = true
+	isCanonical = true
 	req, _ := http.NewRequest("GET", concordanceURL+"?authority=some-authority&identifierValue=some-value&authority=some-authority-yet-again", nil)
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(err)
 	assert.EqualValues(400, res.StatusCode)
+	msg, err := ioutil.ReadAll(res.Body)
+	assert.NoError(err)
+	assert.Contains(string(msg), multipleAuthoritiesNotPermitted)
 }
 
 func TestCanGetOneConcept(t *testing.T) {
 	assert := assert.New(t)
 	isFound = true
+	isCanonical = true
 	req, _ := http.NewRequest("GET", concordanceURL+"?conceptId=bob", nil)
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(err)
 	assert.EqualValues(200, res.StatusCode)
-	assert.Len(conceptIds, 1)
-	assert.Contains(conceptIds, "bob")
+	assert.Equal("bob", conceptId)
 }
 
-func TestCanGetMultipleConcepts(t *testing.T) {
+func TestCanNotGetMultipleConcepts(t *testing.T) {
 	assert := assert.New(t)
 	isFound = true
+	isCanonical = true
 	req, _ := http.NewRequest("GET", concordanceURL+"?conceptId=bob&conceptId=carlos", nil)
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(err)
-	assert.EqualValues(200, res.StatusCode)
-	assert.Len(conceptIds, 2)
-	assert.Contains(conceptIds, "carlos")
+	assert.EqualValues(400, res.StatusCode)
+	msg, err := ioutil.ReadAll(res.Body)
+	assert.NoError(err)
+	assert.Contains(string(msg), multipleConceptIDsNotSupported)
 }
 
 func TestCanParseConceptURI(t *testing.T) {
 	assert := assert.New(t)
 	isFound = true
+	isCanonical = true
 	req, _ := http.NewRequest("GET", concordanceURL+"?conceptId=http://api.ft.com/things/8138ca3f-b80d-3ef8-ad59-6a9b6ea5f15e", nil)
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(err)
 	assert.EqualValues(200, res.StatusCode)
-	assert.Len(conceptIds, 1)
-	assert.Contains(conceptIds, "8138ca3f-b80d-3ef8-ad59-6a9b6ea5f15e")
+	assert.Equal("8138ca3f-b80d-3ef8-ad59-6a9b6ea5f15e", conceptId)
 }
 
 func TestCanNotRequestAuthorityAndConceptId(t *testing.T) {
 	assert := assert.New(t)
 	isFound = true
+	isCanonical = true
 	req, _ := http.NewRequest("GET", concordanceURL+"?conceptId=bob&authority=high-and-mighty", nil)
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(err)
 	assert.EqualValues(400, res.StatusCode)
-
 }
 
 func TestCanNotRequestWithoutAuthorityOrConceptId(t *testing.T) {
 	assert := assert.New(t)
 	isFound = true
+	isCanonical = true
 	req, _ := http.NewRequest("GET", concordanceURL+"?randomRequestParam=bob", nil)
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(err)
 	assert.EqualValues(400, res.StatusCode)
+}
+
+func noRedirect(req *http.Request, via []*http.Request) error {
+	return errors.New("Don't redirect!")
+}
+
+func TestRedirectHappensOnFoundForAlternateNode(t *testing.T) {
+	assert := assert.New(t)
+	isFound = true
+	isCanonical = false
+	request, _ := http.NewRequest("GET", concordanceURL+"?conceptId=bob", nil)
+	cl := &http.Client{
+		CheckRedirect: noRedirect,
+	}
+	result, err := cl.Do(request)
+
+	assert.Contains(err.Error(), "Don't redirect!")
+	assert.EqualValues(301, result.StatusCode)
+	assert.Equal("/concordances?conceptId="+alternativeId, result.Header.Get("Location"))
+	assert.Equal("application/json; charset=UTF-8", result.Header.Get("Content-Type"))
 }


### PR DESCRIPTION
* Remove list endpoints (multiple conceptIds, identifierValues are not supported)
* Redirect added for conceptId - if it is not canonical
* Search concepts by their identifier values (UPP or other)

Supported authorities: 
http://api.ft.com/system/FT-TME, http://api.ft.com/system/FACTSET, http://api.ft.com/system/UPP, http://api.ft.com/system/LEI