### PR TITLE
Removed error handling when no concordances 

### DIFF
--- a/concordances/handlers.go
+++ b/concordances/handlers.go
@@ -104,16 +104,10 @@ func GetConcordances(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	concordance, found, err := processParams(conceptIDExist, authorityExist, m)
+	concordance, _, err := processParams(conceptIDExist, authorityExist, m)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(`{"message": "` + err.Error() + `"}`))
-		return
-	}
-
-	if !found {
-		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte(`{"message":"` + concordanceNotFound + `"}`))
 		return
 	}
 


### PR DESCRIPTION
As we should return an empty list of concordances rather than a 404 when we have no concordances available