### PR TITLE
Async healthcheck

### DIFF
--- a/app.go
+++ b/app.go
@@ -137,10 +137,6 @@ func runServer(neoURL string, port string, cacheDuration string, env string, hea
 
 	servicesRouter := mux.NewRouter()
 
-	// Healthchecks and standards first
-	servicesRouter.HandleFunc("/__health", v1a.Handler("PublicConcordancesRead Healthchecks",
-		"Checks for accessing neo4j", concordances.HealthCheck()))
-
 	// Then API specific ones:
 
 	mh := &handlers.MethodHandler{
@@ -158,6 +154,8 @@ func runServer(neoURL string, port string, cacheDuration string, env string, hea
 	http.HandleFunc(status.BuildInfoPath, status.BuildInfoHandler)
 	http.HandleFunc(status.BuildInfoPathDW, status.BuildInfoHandler)
 	http.HandleFunc("/__gtg", concordances.GoodToGo)
+	http.HandleFunc("/__health", v1a.Handler("PublicConcordancesRead Healthchecks",
+		"Checks for accessing neo4j", concordances.HealthCheck()))
 	http.Handle("/", monitoringRouter)
 
 	if err := http.ListenAndServe(":"+port, nil); err != nil {

--- a/app.go
+++ b/app.go
@@ -64,24 +64,46 @@ func main() {
 		Desc:   "Duration Get requests should be cached for. e.g. 2h45m would set the max-age value to '7440' seconds",
 		EnvVar: "CACHE_DURATION",
 	})
+	logLevel := app.String(cli.StringOpt{
+		Name:   "logLevel",
+		Value:  "info",
+		Desc:   "Log level of the app",
+		EnvVar: "LOG_LEVEL",
+	})
 	healthcheckInterval := app.String(cli.StringOpt{
 		Name:   "healthcheck-interval",
 		Value:  "30s",
 		Desc:   "How often the Neo4j healthcheck is called.",
 		EnvVar: "HEALTHCHECK_INTERVAL",
 	})
+	batchSize := app.Int(cli.IntOpt{
+		Name:   "batch-size",
+		Value:  0,
+		Desc:   "Max batch size for Neo4j queries",
+		EnvVar: "BATCH_SIZE",
+	})
 	app.Action = func() {
 		baseftrwapp.OutputMetricsIfRequired(*graphiteTCPAddress, *graphitePrefix, *logMetrics)
 		log.Infof("public-concordances-api will listen on port: %s, connecting to: %s", *port, *neoURL)
-		runServer(*neoURL, *port, *cacheDuration, *env, *healthcheckInterval)
+		runServer(*neoURL, *port, *cacheDuration, *env, *healthcheckInterval, *batchSize)
 	}
-	log.SetFormatter(&log.TextFormatter{DisableColors: true})
-	log.SetLevel(log.InfoLevel)
-	log.Infof("Application started with args %s", os.Args)
+	log.SetFormatter(&log.JSONFormatter{})
+	lvl, err := log.ParseLevel(*logLevel)
+	if err != nil {
+		log.WithField("LOG_LEVEL", *logLevel).Warn("Cannot parse log level, setting it to INFO.")
+		lvl = log.InfoLevel
+	}
+	log.SetLevel(lvl)
+	log.WithFields(log.Fields{
+		"HEALTHCHECK_INTERVAL": *healthcheckInterval,
+		"CACHE_DURATION":       *cacheDuration,
+		"NEO_URL":              *neoURL,
+		"LOG_LEVEL":            *logLevel,
+	}).Info("Starting app with arguments")
 	app.Run(os.Args)
 }
 
-func runServer(neoURL string, port string, cacheDuration string, env string, healthcheckInterval string) {
+func runServer(neoURL string, port string, cacheDuration string, env string, healthcheckInterval string, batchSize int) {
 
 	if duration, durationErr := time.ParseDuration(cacheDuration); durationErr != nil {
 		log.Fatalf("Failed to parse cache duration string, %v", durationErr)
@@ -90,7 +112,7 @@ func runServer(neoURL string, port string, cacheDuration string, env string, hea
 	}
 
 	conf := neoutils.ConnectionConfig{
-		BatchSize:     1024,
+		BatchSize:     batchSize,
 		Transactional: false,
 		HTTPClient: &http.Client{
 			Transport: &http.Transport{

--- a/concordances/cypher.go
+++ b/concordances/cypher.go
@@ -127,7 +127,7 @@ func (pcw CypherDriver) ReadByAuthority(authority string, identifierValues []str
 }
 
 func (pcw CypherDriver) readByAuthorityNewModel(authority string, identifierValues []string) (concordances Concordances, found bool, err error) {
-	log.Debug("readByAuthorityNewModel")
+	log.Debugf("readByAuthorityNewModel: %v", identifierValues)
 	concordances = Concordances{}
 	results := []neoReadStruct{}
 
@@ -186,7 +186,7 @@ func (pcw CypherDriver) readByAuthorityNewModel(authority string, identifierValu
 }
 
 func (pcw CypherDriver) readByAuthorityOldModel(authority string, identifierValues []string) (concordances Concordances, found bool, err error) {
-	log.Debug("readByAuthorityOldModel")
+	log.Debugf("readByAuthorityOldModel: %v", identifierValues)
 	concordances = Concordances{}
 	results := []neoReadStruct{}
 

--- a/concordances/handlers.go
+++ b/concordances/handlers.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"strings"
 
+	"time"
+
 	"github.com/Financial-Times/go-fthealth/v1a"
 	log "github.com/Sirupsen/logrus"
 )
@@ -16,6 +18,7 @@ import (
 // ConcordanceDriver for cypher queries
 var ConcordanceDriver Driver
 var CacheControlHeader string
+var connCheck error
 
 // HealthCheck does something
 func HealthCheck() v1a.Check {
@@ -29,13 +32,21 @@ func HealthCheck() v1a.Check {
 	}
 }
 
+func StartAsyncChecker(checkInterval time.Duration) {
+	go func(checkInterval time.Duration) {
+		ticker := time.NewTicker(checkInterval)
+		for range ticker.C {
+			connCheck = ConcordanceDriver.CheckConnectivity()
+		}
+	}(checkInterval)
+}
+
 // Checker does more stuff
 func Checker() (string, error) {
-	err := ConcordanceDriver.CheckConnectivity()
-	if err == nil {
-		return "Connectivity to neo4j is ok", err
+	if connCheck == nil {
+		return "Connectivity to neo4j is ok", connCheck
 	}
-	return "Error connecting to neo4j", err
+	return "Error connecting to neo4j", connCheck
 }
 
 //GoodToGo returns a 503 if the healthcheck fails - suitable for use from varnish to check availability of a node

--- a/concordances/handlers.go
+++ b/concordances/handlers.go
@@ -64,6 +64,7 @@ func BuildInfoHandler(w http.ResponseWriter, req *http.Request) {
 // GetConcordances is the public API
 func GetConcordances(w http.ResponseWriter, r *http.Request) {
 
+	log.Debugf("Concordance request: %s", r.URL.RawQuery)
 	m, _ := url.ParseQuery(r.URL.RawQuery)
 
 	_, conceptIDExist := m["conceptId"]


### PR DESCRIPTION
The healthcheck was calling Neo on each request, which was overloading it.  This makes the Neo call asynchronous and variable, and the requests read the cached value.