### PR TITLE
Lists of both old and new model ids weren't being returned properly

### DIFF
--- a/app.go
+++ b/app.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Financial-Times/neo-utils-go/neoutils"
 	"github.com/Financial-Times/public-concordances-api/concordances"
 	status "github.com/Financial-Times/service-status-go/httphandlers"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/jawher/mow.cli"

--- a/concordances/cypher.go
+++ b/concordances/cypher.go
@@ -109,7 +109,7 @@ func (pcw CypherDriver) ReadByAuthority(authority string, identifierValues []str
 	err = pcw.conn.CypherBatch([]*neoism.CypherQuery{query})
 	if err != nil {
 		log.Errorf("Error looking up Concordances with query %s from neoism: %+v\n", query.Statement, err)
-		return Concordances{}, false, fmt.Errorf("Error accessing Concordance datastore for identifier:")
+		return Concordances{}, false, fmt.Errorf("Error accessing Concordance datastore for identifier: %v", identifierValues)
 	}
 
 	if (len(results)) == 0 {

--- a/concordances/cypher.go
+++ b/concordances/cypher.go
@@ -33,10 +33,12 @@ func (pcw CypherDriver) CheckConnectivity() error {
 }
 
 type neoReadStruct struct {
-	UUID          string        `json:"UUID"`
-	Types         []string      `json:"TYPES"`
-	NeoIdentifier neoIdentifier `json:"IDENTIFIERS"`
-	PrefUUID      string        `json:"prefUUID"`
+	UUID                 string        `json:"UUID"`
+	Types                []string      `json:"TYPES"`
+	NeoIdentifier        neoIdentifier `json:"IDENTIFIERS"`
+	PrefUUID             string        `json:"prefUUID"`
+	canonicalTypes       []string      `json:"canonicalTypes"`
+	canonicalIdentifiers neoIdentifier `json:"canonicalIdentifiers"`
 }
 
 type neoIdentifier struct {
@@ -49,22 +51,19 @@ type neoResultStrunct struct {
 }
 
 func (pcw CypherDriver) ReadByConceptID(identifiers []string) (concordances Concordances, found bool, err error) {
-	c, f, err := pcw.readByConceptIDNewModel(identifiers)
-	if !f {
-		c, f, err = pcw.readByConceptIDOldModel(identifiers)
-	}
-	return c, f, err
-}
-
-func (pcw CypherDriver) readByConceptIDNewModel(identifiers []string) (concordances Concordances, found bool, err error) {
 	results := []neoReadStruct{}
 	query := &neoism.CypherQuery{
 		Statement: `
-		MATCH (p:Concept)-[:EQUIVALENT_TO]-(cn:Concept)
-		WHERE p.uuid in {identifiers}
-		MATCH (cn)-[:EQUIVALENT_TO]-(cnn:Concept)
-		RETURN cn.prefUUID as prefUUID, cnn.uuid AS UUID, labels(cnn) AS TYPES, {labels:collect(cnn.authority), value:cnn.authorityValue} as IDENTIFIERS
-		`,
+		MATCH (p:Concept)<-[:IDENTIFIES]-(i:UPPIdentifier)
+		WHERE i.value in {identifiers}
+		MATCH (p:Concept)<-[:IDENTIFIES]-(ids:Identifier)
+		WHERE NOT ids:UPPIdentifier
+        OPTIONAL MATCH (p:Concept)-[:EQUIVALENT_TO]->(canonical:Concept)
+        OPTIONAL MATCH (leafNode:Concept)-[:EQUIVALENT_TO]->(canonical:Concept)
+        OPTIONAL MATCH (leafNode:Concept)<-[:IDENTIFIES]-(leafId:Identifier)
+        WHERE NOT leafId:UPPIdentifier
+	    RETURN canonical.prefUUID as prefUUID, p.uuid AS UUID, labels(p) AS TYPES, labels(p) AS canonicalTypes, {labels:labels(ids), value:ids.value} as IDENTIFIERS,
+        {labels:labels(leafId), value:leafId.value} as canonicalIdentifiers`,
 		Parameters: neoism.Props{"identifiers": identifiers},
 		Result:     &results,
 	}
@@ -83,67 +82,24 @@ func (pcw CypherDriver) readByConceptIDNewModel(identifiers []string) (concordan
 		Concordance: []Concordance{},
 	}
 
-	for _, neoCon := range results {
-		log.Debug(neoCon)
-		var con = Concordance{}
-		var concept = Concept{}
-		concept.ID = mapper.IDURL(neoCon.PrefUUID)
-		concept.APIURL = mapper.APIURL(neoCon.PrefUUID, neoCon.Types, pcw.env)
-		con.Concept = concept
-		con.Identifier = Identifier{Authority: mapNeoLabelsToAuthorityValue(neoCon.NeoIdentifier.Labels), IdentifierValue: neoCon.NeoIdentifier.Value}
-		concordances.Concordance = append(concordances.Concordance, con)
-	}
-
-	if (len(concordances.Concordance)) == 0 {
-		return Concordances{}, false, nil
-	}
-
-	log.Debugf("Returning %v", concordances)
-	return concordances, true, nil
-}
-
-func (pcw CypherDriver) readByConceptIDOldModel(identifiers []string) (concordances Concordances, found bool, err error) {
-	results := []neoReadStruct{}
-	query := &neoism.CypherQuery{
-		Statement: `
-		MATCH (p:Concept)<-[:IDENTIFIES]-(i:UPPIdentifier)
-		WHERE i.value in {identifiers}
-		MATCH (p:Concept)<-[:IDENTIFIES]-(ids:Identifier)
-		WHERE NOT ids:UPPIdentifier
-		RETURN p.uuid as prefUUID, p.uuid AS UUID, labels(p) AS TYPES, {labels:labels(ids), value:ids.value} as IDENTIFIERS
-		`,
-		Parameters: neoism.Props{"identifiers": identifiers},
-		Result:     &results,
-	}
 	return processCypherQueryToConcordances(pcw, query, &results)
+
 }
 
 func (pcw CypherDriver) ReadByAuthority(authority string, identifierValues []string) (concordances Concordances, found bool, err error) {
-	c, f, err := pcw.readByAuthorityNewModel(authority, identifierValues)
-	if !f {
-		c, f, err = pcw.readByAuthorityOldModel(authority, identifierValues)
-	}
-	return c, f, err
-}
-
-func (pcw CypherDriver) readByAuthorityNewModel(authority string, identifierValues []string) (concordances Concordances, found bool, err error) {
-	log.Debugf("readByAuthorityNewModel: %v", identifierValues)
-	concordances = Concordances{}
 	results := []neoReadStruct{}
 
 	authorityProperty := mapAuthorityToAuthorityProperty(authority)
 	if authorityProperty == "" {
 		return Concordances{}, false, nil
 	}
-
-	readByAuthorityQueryStatement := `
-		MATCH (p:Concept)-[:EQUIVALENT_TO]-(cn:Concept)
-		WHERE p.authorityValue in {identifierValues} AND p.authority = {authority}
-		RETURN cn.prefUUID as prefUUID, cn.prefUUID AS UUID, labels(cn) AS TYPES, {labels:collect(p.authority), value:p.authorityValue} as IDENTIFIERS
-		`
-
 	query := &neoism.CypherQuery{
-		Statement: readByAuthorityQueryStatement,
+		Statement: `
+		MATCH (p:Concept)<-[:IDENTIFIES]-(ids:Identifier)
+ 		WHERE ids.value in {identifierValues} AND NOT ids:UPPIdentifier
+        OPTIONAL MATCH (p:Concept)-[:EQUIVALENT_TO]->(canonical:Concept)
+        RETURN canonical.prefUUID as prefUUID, p.uuid AS UUID, labels(p) AS TYPES, labels(canonical) AS canonicalTypes, {labels:labels(ids), value:ids.value} as IDENTIFIERS,
+        {labels:collect(p.authority), value:p.authorityValue} as canonicalIdentifiers`,
 		Parameters: neoism.Props{
 			"identifierValues": identifierValues,
 			"authority":        authorityProperty,
@@ -154,7 +110,7 @@ func (pcw CypherDriver) readByAuthorityNewModel(authority string, identifierValu
 	err = pcw.conn.CypherBatch([]*neoism.CypherQuery{query})
 	if err != nil {
 		log.Errorf("Error looking up Concordances with query %s from neoism: %+v\n", query.Statement, err)
-		return Concordances{}, false, fmt.Errorf("Error accessing Concordance datastore for identifiers: %v", identifierValues)
+		return Concordances{}, false, fmt.Errorf("Error accessing Concordance datastore for identifier:")
 	}
 
 	if (len(results)) == 0 {
@@ -165,51 +121,6 @@ func (pcw CypherDriver) readByAuthorityNewModel(authority string, identifierValu
 		Concordance: []Concordance{},
 	}
 
-	for _, neoCon := range results {
-		log.Debug(neoCon)
-		// Each record is now two identifiers, one UPP and one other.
-		var con = Concordance{}
-		var concept = Concept{}
-		concept.ID = mapper.IDURL(neoCon.PrefUUID)
-		concept.APIURL = mapper.APIURL(neoCon.PrefUUID, neoCon.Types, pcw.env)
-		con.Concept = concept
-		con.Identifier = Identifier{Authority: mapNeoLabelsToAuthorityValue(neoCon.NeoIdentifier.Labels), IdentifierValue: neoCon.NeoIdentifier.Value}
-		concordances.Concordance = append(concordances.Concordance, con)
-	}
-
-	if (len(concordances.Concordance)) == 0 {
-		return Concordances{}, false, nil
-	}
-
-	log.Debugf("Returning %v", concordances)
-	return concordances, true, nil
-}
-
-func (pcw CypherDriver) readByAuthorityOldModel(authority string, identifierValues []string) (concordances Concordances, found bool, err error) {
-	log.Debugf("readByAuthorityOldModel: %v", identifierValues)
-	concordances = Concordances{}
-	results := []neoReadStruct{}
-
-	identifierLabel := mapAuthorityToIdentifierLabel(authority)
-
-	if identifierLabel == "" {
-		return Concordances{}, false, nil
-	}
-
-	readByAuthorityQueryStatement := fmt.Sprintf(`
-		MATCH (p:Concept)<-[:IDENTIFIES]-(i:%s)
-		WHERE i.value in {identifierValues}
-		RETURN p.uuid as prefUUID, p.uuid AS UUID, labels(p) AS TYPES, {labels:labels(i), value:i.value} as IDENTIFIERS
-		`, identifierLabel)
-
-	query := &neoism.CypherQuery{
-		Statement: readByAuthorityQueryStatement,
-		Parameters: neoism.Props{
-			"identifierValues": identifierValues,
-			"authority":        authority,
-		},
-		Result: &results,
-	}
 	return processCypherQueryToConcordances(pcw, query, &results)
 }
 
@@ -220,32 +131,35 @@ func processCypherQueryToConcordances(pcw CypherDriver, q *neoism.CypherQuery, r
 		return Concordances{}, false, fmt.Errorf("Error accessing Concordance datastore")
 	}
 
-	if (len(*results)) == 0 {
-		return Concordances{}, false, nil
-	}
-
 	concordances = neoReadStructToConcordances(results, pcw.env)
 
 	if (len(concordances.Concordance)) == 0 {
 		return Concordances{}, false, nil
 	}
-
-	log.Debugf("Returning %v", concordances)
 	return concordances, true, nil
 }
 
 func neoReadStructToConcordances(neo *[]neoReadStruct, env string) (concordances Concordances) {
-	log.Debug("Running the old model")
 	concordances = Concordances{
 		Concordance: []Concordance{},
 	}
 	for _, neoCon := range *neo {
 		var con = Concordance{}
 		var concept = Concept{}
-		concept.ID = mapper.IDURL(neoCon.UUID)
-		concept.APIURL = mapper.APIURL(neoCon.UUID, neoCon.Types, env)
+
+		if neoCon.PrefUUID != "" {
+			log.Debugf("New concept model with prefUUID: %v", neoCon.PrefUUID)
+			concept.ID = neoCon.PrefUUID
+			con.Identifier = Identifier{Authority: mapNeoLabelsToAuthorityValue(neoCon.canonicalIdentifiers.Labels), IdentifierValue: neoCon.canonicalIdentifiers.Value}
+			concept.APIURL = mapper.APIURL(neoCon.PrefUUID, neoCon.canonicalTypes, env)
+		} else {
+			log.Debugf("Old concept model with UUID: %v", neoCon.UUID)
+			concept.ID = mapper.IDURL(neoCon.UUID)
+			con.Identifier = Identifier{Authority: mapNeoLabelsToAuthorityValue(neoCon.NeoIdentifier.Labels), IdentifierValue: neoCon.NeoIdentifier.Value}
+			concept.APIURL = mapper.APIURL(neoCon.UUID, neoCon.Types, env)
+		}
+
 		con.Concept = concept
-		con.Identifier = Identifier{Authority: mapNeoLabelsToAuthorityValue(neoCon.NeoIdentifier.Labels), IdentifierValue: neoCon.NeoIdentifier.Value}
 		concordances.Concordance = append(concordances.Concordance, con)
 	}
 	return concordances

--- a/concordances/cypher.go
+++ b/concordances/cypher.go
@@ -98,8 +98,7 @@ func (pcw CypherDriver) ReadByAuthority(authority string, identifierValues []str
 		MATCH (p:Concept)<-[:IDENTIFIES]-(ids:Identifier)
  		WHERE ids.value in {identifierValues} AND NOT ids:UPPIdentifier
         OPTIONAL MATCH (p:Concept)-[:EQUIVALENT_TO]->(canonical:Concept)
-        RETURN canonical.prefUUID as prefUUID, p.uuid AS UUID, labels(p) AS TYPES, labels(canonical) AS canonicalTypes, {labels:labels(ids), value:ids.value} as IDENTIFIERS,
-        {labels:collect(p.authority), value:p.authorityValue} as canonicalIdentifiers`,
+        RETURN canonical.prefUUID as prefUUID, p.uuid AS UUID, labels(p) AS TYPES, labels(canonical) AS canonicalTypes, {labels:labels(ids), value:ids.value} as IDENTIFIERS`,
 		Parameters: neoism.Props{
 			"identifierValues": identifierValues,
 			"authority":        authorityProperty,
@@ -150,15 +149,13 @@ func neoReadStructToConcordances(neo *[]neoReadStruct, env string) (concordances
 		if neoCon.PrefUUID != "" {
 			log.Debugf("New concept model with prefUUID: %v", neoCon.PrefUUID)
 			concept.ID = neoCon.PrefUUID
-			con.Identifier = Identifier{Authority: mapNeoLabelsToAuthorityValue(neoCon.canonicalIdentifiers.Labels), IdentifierValue: neoCon.canonicalIdentifiers.Value}
 			concept.APIURL = mapper.APIURL(neoCon.PrefUUID, neoCon.canonicalTypes, env)
 		} else {
 			log.Debugf("Old concept model with UUID: %v", neoCon.UUID)
 			concept.ID = mapper.IDURL(neoCon.UUID)
-			con.Identifier = Identifier{Authority: mapNeoLabelsToAuthorityValue(neoCon.NeoIdentifier.Labels), IdentifierValue: neoCon.NeoIdentifier.Value}
 			concept.APIURL = mapper.APIURL(neoCon.UUID, neoCon.Types, env)
 		}
-
+		con.Identifier = Identifier{Authority: mapNeoLabelsToAuthorityValue(neoCon.NeoIdentifier.Labels), IdentifierValue: neoCon.NeoIdentifier.Value}
 		con.Concept = concept
 		concordances.Concordance = append(concordances.Concordance, con)
 	}

--- a/concordances/cypher.go
+++ b/concordances/cypher.go
@@ -69,7 +69,7 @@ func (pcw CypherDriver) ReadByConceptID(identifiers []string) (concordances Conc
 	err = pcw.conn.CypherBatch([]*neoism.CypherQuery{query})
 	if err != nil {
 		log.Errorf("Error looking up Concordances with query %s from neoism: %+v\n", query.Statement, err)
-		return Concordances{}, false, fmt.Errorf("Error accessing Concordance datastore for identifier:")
+		return Concordances{}, false, fmt.Errorf("Error accessing Concordance datastore for identifier: %v", identifiers)
 	}
 
 	if (len(results)) == 0 {

--- a/concordances/cypher_test.go
+++ b/concordances/cypher_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Financial-Times/organisations-rw-neo4j/organisations"
 	"github.com/jmcvetta/neoism"
 	"github.com/stretchr/testify/assert"
-	"github.com/coreos/fleet/log"
 )
 
 func TestNeoReadByConceptID_NewModel_Unconcorded(t *testing.T) {

--- a/concordances/cypher_test.go
+++ b/concordances/cypher_test.go
@@ -64,7 +64,6 @@ func TestNeoReadByConceptID_NewModel_And_OldModel(t *testing.T) {
 	conc, found, err := undertest.ReadByConceptID([]string{"b20801ac-5a76-43cf-b816-8c3b2f7133ad", "f21a5cc0-d326-4e62-b84a-d840c2209fee"})
 	assert.NoError(err)
 	assert.True(found)
-	log.Infof("Concordances: \n %v", conc)
 	assert.Equal(4, len(conc.Concordance))
 }
 
@@ -248,7 +247,7 @@ func cleanUp(assert *assert.Assertions, db neoutils.NeoConnection) {
 		}, {
 			Statement: fmt.Sprintf("MATCH (a:Thing {uuid: '%s'})--(i:Identifier) DETACH DELETE i, a", "f21a5cc0-d326-4e62-b84a-d840c2209fee"),
 		}, {
-			Statement: fmt.Sprintf("MATCH (a:Thing {uuid: '%s'})--(i:Identifier) DETACH DELETE i, a",  "f9694ba7-eab0-4ce0-8e01-ff64bccb813c"),
+			Statement: fmt.Sprintf("MATCH (a:Thing {uuid: '%s'})--(i:Identifier) DETACH DELETE i, a", "f9694ba7-eab0-4ce0-8e01-ff64bccb813c"),
 		}, {
 			Statement: fmt.Sprintf("MATCH (t:Thing {uuid: '%v'})--(i:Identifier) OPTIONAL MATCH (t)-[:EQUIVALENT_TO]-(e:Thing) DETACH DELETE t, i", "70f4732b-7f7d-30a1-9c29-0cceec23760e"),
 		}, {

--- a/concordances/fixtures/Brand-Concorded-b20801ac-5a76-43cf-b816-8c3b2f7133ad.json
+++ b/concordances/fixtures/Brand-Concorded-b20801ac-5a76-43cf-b816-8c3b2f7133ad.json
@@ -21,9 +21,6 @@
       "aliases": [
         "The Roman"
       ],
-      "parentUUIDs": [
-        "dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54"
-      ],
       "type": "Brand"
     },
     {

--- a/concordances/fixtures/Organisation-Main-3e844449-b27f-40d4-b696-2ce9b6137133.json
+++ b/concordances/fixtures/Organisation-Main-3e844449-b27f-40d4-b696-2ce9b6137133.json
@@ -5,7 +5,10 @@
   "alternativeIdentifiers": {
     "factsetIdentifier": "003JLG-E",
     "uuids": ["3e844449-b27f-40d4-b696-2ce9b6137133"],
-    "leiCode": "7ZW8QJWVPR4P1J1KQY45"
+    "leiCode": "7ZW8QJWVPR4P1J1KQY45",
+    "TME": [
+      "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X05XUw==-T04="
+    ]
   },
   "parentOrganisation": "f9694ba7-eab0-4ce0-8e01-ff64bccb813c",
   "shortName": "Super",

--- a/concordances/handlers.go
+++ b/concordances/handlers.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/Financial-Times/go-fthealth/v1a"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // ConcordanceDriver for cypher queries

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -23,32 +23,26 @@
 			"versionExact": "1.0.1"
 		},
 		{
-			"checksumSHA1": "5b1Y79xoNFuE/XXi5LDN3ys4OYA=",
+			"checksumSHA1": "FfEWrE4sbtmtyeBTHCCF1q3QBxU=",
 			"path": "github.com/Financial-Times/base-ft-rw-app-go/baseftrwapp",
-			"revision": "27f4c78ff5bff819fea09533b4444693bca2136b",
-			"revisionTime": "2017-07-13T11:10:17Z",
-			"version": "1.0.1",
-			"versionExact": "1.0.1"
+			"revision": "0800bf5938ecfb4d343ac396117287d289242c8f",
+			"revisionTime": "2017-08-31T12:49:05Z"
 		},
 		{
-			"checksumSHA1": "7YM7aq6cdSPBLUzrL8H2/yi81BY=",
-			"path": "github.com/Financial-Times/concepts-rw-neo4j",
-			"revision": "a5870df103bb1c6e5c274f7c72429714ed80943a",
-			"revisionTime": "2017-07-18T07:41:22Z",
-			"version": "1.1.0",
-			"versionExact": "1.1.0"
-		},
-		{
-			"checksumSHA1": "vJmggjnU3wcs9cnvPCYapAXzBFg=",
+			"checksumSHA1": "i9JURMjjsZfeoAf/wTyw1y0h+5c=",
 			"path": "github.com/Financial-Times/concepts-rw-neo4j/concepts",
-			"revision": "a5870df103bb1c6e5c274f7c72429714ed80943a",
-			"revisionTime": "2017-07-18T07:41:22Z",
-			"version": "1.1.0",
-			"versionExact": "1.1.0"
+			"revision": "c3a46dd31f8066170f9551ca9574004ee7f6ba7a",
+			"revisionTime": "2017-08-30T10:26:13Z"
 		},
 		{
 			"checksumSHA1": "6U1V2xI8bHaR95+gN+VfO9TqClE=",
 			"path": "github.com/Financial-Times/go-fthealth",
+			"revision": "e7ccca038327a0091303a52445ec1f0fb66cb97b",
+			"revisionTime": "2017-05-25T09:50:41Z"
+		},
+		{
+			"checksumSHA1": "fNgRM8ZlaDzdvSpuhSdGxEOrWi4=",
+			"path": "github.com/Financial-Times/go-fthealth/v1_1",
 			"revision": "e7ccca038327a0091303a52445ec1f0fb66cb97b",
 			"revisionTime": "2017-05-25T09:50:41Z"
 		},
@@ -59,10 +53,10 @@
 			"revisionTime": "2017-05-25T09:50:41Z"
 		},
 		{
-			"checksumSHA1": "zUpINnstJChGK0LAtkt7jBc3RY0=",
+			"checksumSHA1": "dqF1g4reeLPNN10qTXgDJj3fHm4=",
 			"path": "github.com/Financial-Times/http-handlers-go/httphandlers",
-			"revision": "bb69c454da9050fe1c4b92fe1345a01583ee70be",
-			"revisionTime": "2016-08-03T10:40:03Z"
+			"revision": "229ac16f1d9ec9bca485d2dafb9ec14dc7e9ba24",
+			"revisionTime": "2017-08-09T12:10:07Z"
 		},
 		{
 			"checksumSHA1": "ZmT6PPQSF7C4aHQ2HO8QsKtYStg=",
@@ -71,10 +65,10 @@
 			"revisionTime": "2017-04-05T08:23:10Z"
 		},
 		{
-			"checksumSHA1": "IDKJ/mqVeFl91y07EpjO6Kbnwnc=",
+			"checksumSHA1": "ibld3tkf8qmEKpF69JI4mrSN0T8=",
 			"path": "github.com/Financial-Times/neo-utils-go/neoutils",
-			"revision": "aed125896a5ac0b50296fde5faefed1ebfa7fae3",
-			"revisionTime": "2017-01-04T12:16:44Z"
+			"revision": "5cb1750096545b3c8f7384326247e3e30996a905",
+			"revisionTime": "2017-08-22T15:20:35Z"
 		},
 		{
 			"checksumSHA1": "evf7aLwBJa9H43TUXwSdB8qEUPs=",
@@ -85,8 +79,8 @@
 		{
 			"checksumSHA1": "OViPZtQxGJ8ECf9BBDvQ112tzP4=",
 			"path": "github.com/Financial-Times/organisations-rw-neo4j/organisations",
-			"revision": "cb217caf77f1e60a4b8eed7e30416e02c350467f",
-			"revisionTime": "2017-07-10T14:00:21Z"
+			"revision": "4e2021b3a6e763cc6f4a115676bfbdfa1790c4cd",
+			"revisionTime": "2017-08-31T14:44:53Z"
 		},
 		{
 			"checksumSHA1": "fqpohN7Qp2qj7TLMbUxh/cK4oH0=",
@@ -119,12 +113,6 @@
 			"revisionTime": "2017-07-10T12:58:28Z",
 			"version": "1.0.0",
 			"versionExact": "1.0.0"
-		},
-		{
-			"checksumSHA1": "Cag+3Y9IpGeyM+7Li1AkHdcaTyg=",
-			"path": "github.com/Sirupsen/logrus",
-			"revision": "5ff5dd844dfeb4e23e27528f79f1f845bc8bb78f",
-			"revisionTime": "2017-07-17T07:50:14Z"
 		},
 		{
 			"checksumSHA1": "/6H1rhQmbq8mEP29pnmLmdwBKUE=",
@@ -217,6 +205,12 @@
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
+			"checksumSHA1": "BYvROBsiyAXK4sq6yhDe8RgT4LM=",
+			"path": "github.com/sirupsen/logrus",
+			"revision": "89742aefa4b206dcf400792f3bd35b542998eb3b",
+			"revisionTime": "2017-08-22T13:27:46Z"
+		},
+		{
 			"checksumSHA1": "J+ppEq6nYMKxhB9+c+MD1x9UwSc=",
 			"path": "github.com/stretchr/testify/assert",
 			"revision": "05e8a0eda380579888eb53c394909df027f06991",
@@ -229,6 +223,12 @@
 			"revisionTime": "2017-05-24T23:16:39Z"
 		},
 		{
+			"checksumSHA1": "nqWNlnMmVpt628zzvyo6Yv2CX5Q=",
+			"path": "golang.org/x/crypto/ssh/terminal",
+			"revision": "81e90905daefcd6fd217b62423c0908922eadb30",
+			"revisionTime": "2017-08-25T20:24:07Z"
+		},
+		{
 			"checksumSHA1": "dr5+PfIRzXeN+l1VG+s0lea9qz8=",
 			"path": "golang.org/x/net/context",
 			"revision": "b3756b4b77d7b13260a0a2ec658753cf48922eac",
@@ -239,6 +239,12 @@
 			"path": "golang.org/x/sys/unix",
 			"revision": "4cd6d1a821c7175768725b55ca82f14683a29ea4",
 			"revisionTime": "2017-07-14T13:21:52Z"
+		},
+		{
+			"checksumSHA1": "gVfCD++7aVcdKF2spv6XkEM/wYw=",
+			"path": "golang.org/x/sys/windows",
+			"revision": "bb24a47a89eac6c1227fbcb2ae37a8b9ed323366",
+			"revisionTime": "2017-08-30T08:51:02Z"
 		},
 		{
 			"checksumSHA1": "k3L1Q7anlDsX2njPAE5Dd2SWVlw=",


### PR DESCRIPTION
The query to return the concordances wasn't working when there was a mix of old model and new model identifiers. This fixes that. Also it adds more detailed tests. Also it fixes the horrid Sirupsen stuff