### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Public Concordances API
 
 Public Concordances API provides a public API for retrieving concordances stored in the Neo4j graph database.
@@ -8,7 +12,7 @@ public-concordances-api
 
 ## Primary URL
 
-<https://api.ft.com/concordances>
+https://api.ft.com/concordances
 
 ## Service Tier
 
@@ -18,23 +22,6 @@ Platinum
 
 Production
 
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- dimitar.terziev
-- elitsa.pavlova
-- kalin.arsov
-- ivan.nikolov
-- miroslav.gatsanoga
-- marina.chompalova
-
 ## Host Platform
 
 AWS
@@ -43,10 +30,10 @@ AWS
 
 The service provides the following endpoints for the retrieval of concordance data:
 
-- GET `/concordances?conceptId={thingUri}` - returns a list of all identifiers for a given concept.
-- GET `/concordances?conceptId={thingUri}&conceptId={thingUri}...` - returns a list of all identifiers for each provided concept.
-- GET `/concordances?authority={identifierUri}&identifierValue{identifierValue}` - returns the apiURL that matches the corresponding identifier.
-- GET `/concordances?authority={identifierUri}&identifierValue={identifierValue}&identifierValue={identifierValue}` - returns a list of all apiURLs for the corresponding identifiers.
+*   GET `/concordances?conceptId={thingUri}` - returns a list of all identifiers for a given concept.
+*   GET `/concordances?conceptId={thingUri}&conceptId={thingUri}...` - returns a list of all identifiers for each provided concept.
+*   GET `/concordances?authority={identifierUri}&identifierValue{identifierValue}` - returns the apiURL that matches the corresponding identifier.
+*   GET `/concordances?authority={identifierUri}&identifierValue={identifierValue}&identifierValue={identifierValue}` - returns a list of all apiURLs for the corresponding identifiers.
 
 ## Contains Personal Data
 
@@ -56,9 +43,19 @@ No
 
 No
 
-## Dependencies
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-- upp-neo4j-cluster
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -97,6 +94,14 @@ Manual
 
 The release is triggered by making a Github release which is then picked up by a Jenkins multibranch pipeline. The Jenkins pipeline should be manually started in order for it to deploy the helm package to the Kubernetes clusters.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 NotApplicable
@@ -109,8 +114,8 @@ There is no key rotation procedure for this system.
 
 Service in UPP K8S delivery clusters:
 
-- Delivery-Prod-EU health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=public-concordances-api>
-- Delivery-Prod-US health: <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=public-concordances-api>
+*   Delivery-Prod-EU health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=public-concordances-api>
+*   Delivery-Prod-US health: <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=public-concordances-api>
 
 ## First Line Troubleshooting
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/public-concordances-api/blob/runbook-no-relationships-2021-03-19/runbooks/runbook.md) file has been automatically regenerated from the Biz Ops data for the **public-concordances-api** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **public-concordances-api** system in [Biz Ops](https://biz-ops.in.ft.com/System/public-concordances-api).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
