### PR TITLE
Adding shared context instead of env vars in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,9 @@ workflows:
           name: build-docker-image
           requires:
             - build-and-test-project
-          context: dockerhub-shared
+          context: 
+            - dockerhub-shared
+            - cm-team-github
   snyk-scanning:
     jobs:
       - ft-golang-ci/scan:


### PR DESCRIPTION
# Description

## What

Adding shared context instead of env vars in circleci config. Rotating COVERALLS_TOKEN.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-4143)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
