### PR TITLE
Add reading concepts with Generic authority

### DIFF
--- a/concordances/cypher_test.go
+++ b/concordances/cypher_test.go
@@ -539,6 +539,40 @@ var expectedConcordanceSVCategoryByAuthority = Concordances{
 	},
 }
 
+var expectedConcordancePersonGeneric = Concordances{
+	[]Concordance{
+		{
+			Concept{
+				ID:     "http://api.ft.com/things/3c4666ef-b403-4313-b648-d639762750e4",
+				APIURL: "http://api.ft.com/people/3c4666ef-b403-4313-b648-d639762750e4"},
+			Identifier{
+				Authority:       "http://api.ft.com/system/UPP",
+				IdentifierValue: "3c4666ef-b403-4313-b648-d639762750e4"},
+		},
+		{
+			Concept{
+				ID:     "http://api.ft.com/things/3c4666ef-b403-4313-b648-d639762750e4",
+				APIURL: "http://api.ft.com/people/3c4666ef-b403-4313-b648-d639762750e4"},
+			Identifier{
+				Authority:       "http://api.ft.com/system/GENERIC",
+				IdentifierValue: "3c4666ef-b403-4313-b648-d639762750e4"},
+		},
+	},
+}
+
+var expectedConcordancePersonGenericByAuthority = Concordances{
+	[]Concordance{
+		{
+			Concept{
+				ID:     "http://api.ft.com/things/3c4666ef-b403-4313-b648-d639762750e4",
+				APIURL: "http://api.ft.com/people/3c4666ef-b403-4313-b648-d639762750e4"},
+			Identifier{
+				Authority:       "http://api.ft.com/system/GENERIC",
+				IdentifierValue: "3c4666ef-b403-4313-b648-d639762750e4"},
+		},
+	},
+}
+
 func TestNeoReadByConceptID(t *testing.T) {
 	driver := getNeoDriver(assert.New(t))
 
@@ -632,6 +666,13 @@ func TestNeoReadByConceptID(t *testing.T) {
 			conceptIDs:  []string{"a671f5a9-b9a4-4836-a174-fc273166f0db"},
 			expectedLen: 2,
 			expected:    expectedConcordanceFTAPersonDetails,
+		},
+		{
+			name:        "PersonGeneric",
+			fixture:     "Person-Generic-3c4666ef-b403-4313-b648-d639762750e4.json",
+			conceptIDs:  []string{"3c4666ef-b403-4313-b648-d639762750e4"},
+			expectedLen: 2,
+			expected:    expectedConcordancePersonGeneric,
 		},
 		{
 			name:        "SVCategory",
@@ -808,6 +849,13 @@ func TestNeoReadByAuthority(t *testing.T) {
 			authority:        "http://api.ft.com/system/19d50190-8656-4e91-8d34-82e646ada9c9",
 			identifierValues: []string{"a671f5a9-b9a4-4836-a174-fc273166f0db"},
 			expected:         expectedConcordanceFTAPersonDetailsByAuthority,
+		},
+		{
+			name:             "PersonGeneric",
+			fixture:          "Person-Generic-3c4666ef-b403-4313-b648-d639762750e4.json",
+			authority:        "http://api.ft.com/system/GENERIC",
+			identifierValues: []string{"3c4666ef-b403-4313-b648-d639762750e4"},
+			expected:         expectedConcordancePersonGenericByAuthority,
 		},
 		{
 			name:             "SVCategory",

--- a/concordances/fixtures/Person-Generic-3c4666ef-b403-4313-b648-d639762750e4.json
+++ b/concordances/fixtures/Person-Generic-3c4666ef-b403-4313-b648-d639762750e4.json
@@ -1,0 +1,17 @@
+{
+    "aliases": [
+        "Amy Winehouse"
+    ],
+    "prefLabel": "Amy Winehouse",
+    "prefUUID": "3c4666ef-b403-4313-b648-d639762750e4",
+    "sourceRepresentations": [
+        {
+            "authority": "Generic",
+            "authorityValue": "3c4666ef-b403-4313-b648-d639762750e4",
+            "prefLabel": "Amy Winehouse",
+            "type": "Person",
+            "uuid": "3c4666ef-b403-4313-b648-d639762750e4"
+        }
+    ],
+    "type": "Person"
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.2
 
 require (
 	github.com/Financial-Times/api-endpoint v1.0.0
-	github.com/Financial-Times/cm-graph-ontology/v2 v2.0.13
+	github.com/Financial-Times/cm-graph-ontology/v2 v2.0.14
 	github.com/Financial-Times/cm-neo4j-driver v1.1.1
 	github.com/Financial-Times/go-fthealth v0.0.0-20171204124831-1b007e2b37b7
 	github.com/Financial-Times/go-logger/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Financial-Times/api-endpoint v1.0.0 h1:EhJfcVcrktPrweue6dCUQAYcEQiXwh+1byIc8a1nypE=
 github.com/Financial-Times/api-endpoint v1.0.0/go.mod h1:QrJsxP8uEZIPJZon+qhc+zO7H0634DpoqDI291i0Nag=
-github.com/Financial-Times/cm-graph-ontology/v2 v2.0.13 h1:zWHcAjGHUPKmc4BjccrOMXuU7pr+XEvkuZUqg3Duj1c=
-github.com/Financial-Times/cm-graph-ontology/v2 v2.0.13/go.mod h1:HNytPLbek0HwF5KX8m5cGNZ/HTdtXwTisR3HmCk7O/o=
+github.com/Financial-Times/cm-graph-ontology/v2 v2.0.14 h1:W4OIzmHPSP++hoFuydrrx1/DYXL1N9uQwHFHg8vglfM=
+github.com/Financial-Times/cm-graph-ontology/v2 v2.0.14/go.mod h1:HNytPLbek0HwF5KX8m5cGNZ/HTdtXwTisR3HmCk7O/o=
 github.com/Financial-Times/cm-neo4j-driver v1.1.1 h1:kmgRa3boe58+tzNTbWTBx3IQnIZt5Hh57Yc2kHy85FM=
 github.com/Financial-Times/cm-neo4j-driver v1.1.1/go.mod h1:fQ77C8A+6I+ihwe6Ob8Y7sIzU3s/DTrjBZJGVQOeum0=
 github.com/Financial-Times/go-fthealth v0.0.0-20171204124831-1b007e2b37b7 h1:dkf1EOTiHXA2lG2EJuePEim6y0HEOPt0hcqsT/qUr/k=


### PR DESCRIPTION
# Description

## What

Update cm-graph-ontology library and allow reading generic concept authority.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-5406)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [x] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
